### PR TITLE
Expose `TypedFetch`

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -10,6 +10,7 @@ import type {
   OpErrorType,
   OpDefaultReturnType,
   OpReturnType,
+  TypedFetch,
 } from './types'
 
 import { ApiError } from './types'
@@ -24,6 +25,7 @@ export type {
   FetchErrorType,
   ApiResponse,
   Middleware,
+  TypedFetch,
 }
 
 export { Fetcher, ApiError }


### PR DESCRIPTION
Exposes `TypedFetch` to the user of the package. The reasoning can be found in #11. 

Closes #11.