### PR TITLE
Change encodeURIComponent to encodeURI

### DIFF
--- a/src/fetcher.ts
+++ b/src/fetcher.ts
@@ -25,7 +25,7 @@ function queryString(params: Record<string, unknown>): string {
   const qs: string[] = []
 
   const encode = (key: string, value: unknown) =>
-    `${encodeURIComponent(key)}=${encodeURIComponent(String(value))}`
+    `${encodeURI(key)}=${encodeURI(String(value))}`
 
   Object.keys(params).forEach((key) => {
     const value = params[key]
@@ -47,7 +47,7 @@ function queryString(params: Record<string, unknown>): string {
 
 function getPath(path: string, payload: Record<string, any>) {
   return path.replace(/\{([^}]+)\}/g, (_, key) => {
-    const value = encodeURIComponent(payload[key])
+    const value = encodeURI(payload[key])
     delete payload[key]
     return value
   })


### PR DESCRIPTION
encodeURIComponent is too greedy and encodes some characters that shouldn't be encoded. For instance, https://foo.com/bar:123 is a valid URL, but encodeURIComponents ends up encoding the ':'

I think it should be using encodeURI instead