### PR TITLE
Create package.json for esm and cjs distributions

### DIFF
--- a/fixup
+++ b/fixup
@@ -1,0 +1,19 @@
+#!/bin/bash
+#
+#   Add package.json files to cjs/mjs subtrees
+#
+
+cat >dist/cjs/package.json <<!EOF
+{
+    "type": "commonjs"
+}
+!EOF
+
+cat >dist/esm/package.json <<!EOF
+{
+    "type": "module"
+}
+!EOF
+
+find src -name '*.d.ts' -exec cp {} dist/cjs \;
+find src -name '*.d.ts' -exec cp {} dist/esm \;

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
   },
   "scripts": {
     "clean": "rimraf './dist'",
-    "build": "npm run clean && tsc --project tsconfig.json && tsc --project tsconfig.cjs.json",
+    "build": "npm run clean && tsc --project tsconfig.json && tsc --project tsconfig.cjs.json && ./fixup",
     "lint": "eslint .",
     "prepare": "npm run build",
     "test": "npm run build && jest",

--- a/src/fetcher.ts
+++ b/src/fetcher.ts
@@ -13,7 +13,7 @@ import {
   Request,
   _TypedFetch,
   TypedFetch,
-} from './types'
+} from './types.js'
 
 const sendBody = (method: Method) =>
   method === 'post' ||

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
-import { Fetcher } from './fetcher'
-import { arrayRequestBody } from './utils'
+import { Fetcher } from './fetcher.js'
+import { arrayRequestBody } from './utils.js'
 
 import type {
   ApiResponse,
@@ -14,7 +14,7 @@ import type {
   TypedFetch,
 } from './types'
 
-import { ApiError } from './types'
+import { ApiError } from './types.js'
 
 export type {
   OpArgType,


### PR DESCRIPTION
I faced the issue that I could not import `openapi-typescript-fetch` as ESM. 
After some research, I think it's related to missing package.json to specify `type` in the distributions.
See https://www.sensedeep.com/blog/posts/2021/how-to-create-single-source-npm-module.html for an example.

This pull request adds `package.json` in the `dist` folders with `module` `commonjs`/`module`.