### PR TITLE
Fix OpResponseTypes to support negotiated content types

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -37,7 +37,7 @@ type OpResponseTypes<OP> = OP extends {
   ? {
       [S in keyof R]: R[S] extends { schema?: infer S } // openapi 2
         ? S
-        : R[S] extends { content: { 'application/json': infer C } } // openapi 3
+        : R[S] extends { content: { [P in keyof R[S] as `application/${string}json`]: infer C; } } // openapi 3
         ? C
         : S extends 'default'
         ? R[S]


### PR DESCRIPTION
OpenAPI spec supports content negotiation, in my use case we use this to support API versioning.

So, our spec results in a generated schema type such as this:

```
    "200-items": {
      content: {
        "application/items.v1+json": {
          items?: components["schemas"]["items"][];
        };
      };
    };
```

In the current typings for openapi-typescript-fetch a hard-coded 'application/json' string is used to infer the response types. Which breaks in the case of our schema...

This PR adds a templated literal to accommodate for situations where something other than 'application/json' is used, while remaining backwards compatible.