### PR TITLE
Fix OpReturnType to support 202 status code

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -49,6 +49,8 @@ type _OpReturnType<T> = 200 extends keyof T
   ? T[200]
   : 201 extends keyof T
   ? T[201]
+  : 202 extends keyof T
+  ? T[202]
   : 'default' extends keyof T
   ? T['default']
   : unknown
@@ -65,11 +67,11 @@ export type OpDefaultReturnType<OP> = _OpDefaultReturnType<OpResponseTypes<OP>>
 const never: unique symbol = Symbol()
 
 type _OpErrorType<T> = {
-  [S in Exclude<keyof T, 200 | 201>]: {
+  [S in Exclude<keyof T, 200 | 201 | 202>]: {
     status: S extends 'default' ? typeof never : S
     data: T[S]
   }
-}[Exclude<keyof T, 200 | 201>]
+}[Exclude<keyof T, 200 | 201 | 202>]
 
 type Coalesce<T, D> = [T] extends [never] ? D : T
 

--- a/test/fetch.test.ts
+++ b/test/fetch.test.ts
@@ -111,6 +111,13 @@ describe('fetch', () => {
     expect(data.headers).not.toHaveProperty('content-type')
   })
 
+  it(`POST /accepted`, async () => {
+    const fun = fetcher.path('/accepted').method('post').create()
+    const { status, data } = await fun(undefined)
+    expect(status).toBe(202)
+    expect(data.message).toBe('Accepted')
+  })
+
   it(`POST /nocontent`, async () => {
     const fun = fetcher.path('/nocontent').method('post').create()
     const { status, data } = await fun(undefined)

--- a/test/mocks/handlers.ts
+++ b/test/mocks/handlers.ts
@@ -49,6 +49,11 @@ const methods = {
   withBodyAndQuery: ['post', 'put', 'patch', 'delete'].map((method) => {
     return (rest as any)[method](`${HOST}/bodyquery/:id`, getResult)
   }),
+  withAccepted: [
+    rest.post(`${HOST}/accepted`, (req, res, ctx) => {
+      return res(ctx.status(202), ctx.json({ message: 'Accepted' }))
+    }),
+  ],
   withError: [
     rest.get(`${HOST}/error/:status`, (req, res, ctx) => {
       const status = Number(req.params.status)
@@ -81,5 +86,6 @@ export const handlers = [
   ...methods.withBody,
   ...methods.withBodyArray,
   ...methods.withBodyAndQuery,
+  ...methods.withAccepted,
   ...methods.withError,
 ]

--- a/test/paths.ts
+++ b/test/paths.ts
@@ -61,6 +61,14 @@ export type paths = {
     patch: BodyAndQuery
     delete: BodyAndQuery
   }
+  '/accepted': {
+    post: {
+      parameters: {}
+      responses: {
+        202: { schema: { message: string } }
+      }
+    }
+  }
   '/nocontent': {
     post: {
       parameters: {}


### PR DESCRIPTION
Partially fixed #35, supporting 202 as Success response.

To manage long-running jobs behind an API, 202 is necessary to describe the situation, that "job is accepted but not finished yet."