### PR TITLE
Support file downloads

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,49 @@ try {
 }
 ```
 
+### Binary Data
+
+It is possible to handle some content types as binary data.
+You can specify these as a string, regular expression, list of regular expressions and/or strings, or a custom discriminator function
+If one of the strings or regular expressions you provided matches the Content-Type header returned by the endpoint,
+or your discriminator function, called with the contents of the Content-Type header, returns `true`, the response body will be returned as a [binary blob](https://developer.mozilla.org/en-US/docs/Web/API/Blob).
+
+```ts
+
+fetcher.configure({
+  baseUrl: 'https://example.com/api',
+  asBlob: 'application/octet-stream'
+})
+
+// or
+
+fetcher.configure({
+  baseUrl: 'https://example.com/api',
+  asBlob: /^application\/(?!json)/
+})
+
+// or
+
+fetcher.configure({
+  baseUrl: 'https://example.com/api',
+  asBlob: ['application/pdf', 'audio/vorbis']
+})
+
+// or
+
+fetcher.configure({
+  baseUrl: 'https://example.com/api',
+  asBlob: (contentType: string) => contentType.startsWith('application/o')
+})
+
+// data is going to be a Blob
+const { data } = await fetcher.path('/binary/data').method('get').create()(
+  {},
+  { headers: { Accept: 'application/octet-stream' } },
+)
+
+```
+
 ### Middleware
 
 Middlewares can be used to pre and post process fetch operations (log api calls, add auth headers etc)

--- a/src/fetcher.ts
+++ b/src/fetcher.ts
@@ -140,7 +140,7 @@ async function getResponseData(response: Response) {
     return undefined
   }
   if (contentType && contentType.indexOf('application/json') !== -1) {
-    return await response.json()
+    return response.json()
   }
   const text = await response.text()
   try {

--- a/src/types.ts
+++ b/src/types.ts
@@ -127,10 +127,19 @@ export type Middleware = (
   next: Fetch,
 ) => Promise<ApiResponse>
 
+export type BlobTypeSelector = (contentType: string) => boolean
+
+export type ContentTypeDiscriminator =
+  | string
+  | RegExp
+  | Array<string | RegExp>
+  | BlobTypeSelector
+
 export type FetchConfig = {
   baseUrl?: string
   init?: RequestInit
   use?: Middleware[]
+  asBlob?: ContentTypeDiscriminator
 }
 
 export type Request = {

--- a/test/mocks/handlers.ts
+++ b/test/mocks/handlers.ts
@@ -36,6 +36,13 @@ function getResult(
   )
 }
 
+function getBlob(req: RestRequest, res: ResponseComposition, ctx: RestContext) {
+  return res(
+    ctx.body(new Blob([(req.body as Record<string, string>)['value']])),
+    ctx.set('Content-Type', req.headers.get('accept') ?? 'application/pdf'),
+  )
+}
+
 const HOST = 'https://api.backend.dev'
 
 const methods = {
@@ -49,6 +56,10 @@ const methods = {
   withBodyAndQuery: ['post', 'put', 'patch', 'delete'].map((method) => {
     return (rest as any)[method](`${HOST}/bodyquery/:id`, getResult)
   }),
+  withBlob: [
+    rest.get(`${HOST}/blob`, getBlob),
+    rest.post(`${HOST}/blob`, getBlob),
+  ],
   withError: [
     rest.get(`${HOST}/error/:status`, (req, res, ctx) => {
       const status = Number(req.params.status)
@@ -79,6 +90,7 @@ const methods = {
 export const handlers = [
   ...methods.withQuery,
   ...methods.withBody,
+  ...methods.withBlob,
   ...methods.withBodyArray,
   ...methods.withBodyAndQuery,
   ...methods.withError,

--- a/test/paths.ts
+++ b/test/paths.ts
@@ -39,6 +39,17 @@ type BodyAndQuery = {
   responses: { 201: { schema: Data } }
 }
 
+type BodyBlob = {
+  parameters: {
+    body: { payload: { value: string } }
+  }
+  responses: {
+    200: {
+      schema: unknown
+    }
+  }
+}
+
 export type paths = {
   '/query/{a}/{b}': {
     get: Query
@@ -60,6 +71,9 @@ export type paths = {
     put: BodyAndQuery
     patch: BodyAndQuery
     delete: BodyAndQuery
+  }
+  '/blob': {
+    post: BodyBlob
   }
   '/nocontent': {
     post: {


### PR DESCRIPTION
I am using this software on a project where for some endpoints, we receive a PDF or image file in response. The current response handling in openapi-typescript-fetch makes it hard to extract the file from the response.

I propose that (instead of adding some heuristic for what is binary data and what is not), the user should be able to specify which mime types to handle as binary data and return response.blob() in the data property. This also solves issue https://github.com/ajaishankar/openapi-typescript-fetch/issues/10.

Happy to improve upon this code in any way neccessary in order to get it merged.