### PR TITLE
Status should always be a `number` in OpErrorType

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -63,12 +63,9 @@ type _OpDefaultReturnType<T> = 'default' extends keyof T
 
 export type OpDefaultReturnType<OP> = _OpDefaultReturnType<OpResponseTypes<OP>>
 
-// private symbol to prevent narrowing on "default" error status
-const never: unique symbol = Symbol()
-
 type _OpErrorType<T> = {
   [S in Exclude<keyof T, 200 | 201 | 204>]: {
-    status: S extends 'default' ? typeof never : S
+    status: S extends 'default' ? number : S
     data: T[S]
   }
 }[Exclude<keyof T, 200 | 201 | 204>]


### PR DESCRIPTION
the private `never: unique symbol` causes inferred types to "references an inaccessible 'unique symbol' type." in places where explicit type annotations are not possible.

It doesn't seem necessary to use `typeof never`, as `number` should work just as well.